### PR TITLE
Fix a bug about register allocation in `Aarch64VCpu::run_guest` which may cause damaged stack

### DIFF
--- a/src/exception.rs
+++ b/src/exception.rs
@@ -23,10 +23,10 @@ pub enum TrapKind {
 }
 }
 
-/// This is equal to the type defined by the `TrapKind` enum.
-/// TODO: How can we reuse `TrapKind` directly?
-const EXCEPTION_SYNC: usize = 0;
-const EXCEPTION_IRQ: usize = 1;
+/// Equals to [`TrapKind::Synchronous`], used in exception.S.
+const EXCEPTION_SYNC: usize = TrapKind::Synchronous as usize;
+/// Equals to [`TrapKind::Irq`], used in exception.S.
+const EXCEPTION_IRQ: usize = TrapKind::Irq as usize;
 
 #[repr(u8)]
 #[derive(Debug)]


### PR DESCRIPTION
The core part of `Aarch64VCpu::run_guest` is:

```rust
core::arch::asm!(
    save_regs_to_stack!(),  // Save host context.
    "mov x9, sp",
    "mov x10, {0}",
    "str x9, [x10]",    // Save current host stack top in the `Aarch64VCpu` struct.
    "mov x0, {0}",
    "b context_vm_entry",
    in(reg) &self.host_stack_top as *const _ as usize,
    out("x0") ret,
    options(nostack)
);
```

`in(reg)` here is dangerous, as compiler may assign `x9` or `x10` to this value, which results in a conflict and damaged stack.