### PR TITLE
fix: modify the maintenance of host sp_el0

### DIFF
--- a/src/context_frame.rs
+++ b/src/context_frame.rs
@@ -32,7 +32,7 @@ impl core::fmt::Display for Aarch64ContextFrame {
         for i in 0..31 {
             write!(f, "x{:02}: {:016x}   ", i, self.gpr[i])?;
             if (i + 1) % 2 == 0 {
-                write!(f, "\n")?;
+                writeln!(f)?;
             }
         }
         writeln!(f, "spsr:{:016x}", self.spsr)?;
@@ -54,7 +54,7 @@ impl Aarch64ContextFrame {
                 + SPSR_EL1::F::Masked
                 + SPSR_EL1::A::Masked
                 + SPSR_EL1::D::Masked)
-                .value as u64,
+                .value,
             elr: 0,
             sp: 0,
         }
@@ -76,7 +76,7 @@ impl Aarch64ContextFrame {
                 + SPSR_EL1::F::Masked
                 + SPSR_EL1::A::Masked
                 + SPSR_EL1::D::Masked)
-                .value as u64,
+                .value,
             elr: pc as u64,
             sp: sp as u64,
         };

--- a/src/context_frame.rs
+++ b/src/context_frame.rs
@@ -175,7 +175,7 @@ impl Aarch64ContextFrame {
 
 /// Represents the VM context for a guest virtual machine in a hypervisor environment.
 ///
-/// The `VmContext` structure contains various registers and states needed to manage
+/// The `GuestSystemRegisters` structure contains various registers and states needed to manage
 /// and restore the context of a virtual machine (VM). This includes timer registers,
 /// system control registers, exception registers, and hypervisor-specific registers.
 ///
@@ -183,7 +183,7 @@ impl Aarch64ContextFrame {
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Clone, Copy, Default)]
-pub struct VmContext {
+pub struct GuestSystemRegisters {
     // generic timer
     pub cntvoff_el2: u64,
     cntp_cval_el0: u64,
@@ -234,161 +234,68 @@ pub struct VmContext {
     hpfar_el2: u64,
 }
 
-impl VmContext {
-    /// Creates a new `VmContext` with all registers initialized to zero.
-    ///
-    /// This method returns a `VmContext` instance with default values,
-    /// ensuring that all fields are set to zero.
-    pub fn default() -> VmContext {
-        VmContext {
-            // generic timer
-            cntvoff_el2: 0,
-            cntp_cval_el0: 0,
-            cntv_cval_el0: 0,
-            cntkctl_el1: 0,
-            cntvct_el0: 0,
-            cntp_ctl_el0: 0,
-            cntv_ctl_el0: 0,
-            cntp_tval_el0: 0,
-            cntv_tval_el0: 0,
-
-            // vpidr and vmpidr
-            vpidr_el2: 0,
-            vmpidr_el2: 0,
-
-            // 64bit EL1/EL0 register
-            sp_el0: 0,
-            sp_el1: 0,
-            elr_el1: 0,
-            spsr_el1: 0,
-            sctlr_el1: 0,
-            actlr_el1: 0,
-            cpacr_el1: 0,
-            ttbr0_el1: 0,
-            ttbr1_el1: 0,
-            tcr_el1: 0,
-            esr_el1: 0,
-            far_el1: 0,
-            par_el1: 0,
-            mair_el1: 0,
-            amair_el1: 0,
-            vbar_el1: 0,
-            contextidr_el1: 0,
-            tpidr_el0: 0,
-            tpidr_el1: 0,
-            tpidrro_el0: 0,
-
-            // hypervisor context
-            hcr_el2: 0,
-            cptr_el2: 0,
-            hstr_el2: 0,
-
-            // exception
-            pmcr_el0: 0,
-            vtcr_el2: 0,
-            vttbr_el2: 0,
-            far_el2: 0,
-            hpfar_el2: 0,
-        }
-    }
-
+impl GuestSystemRegisters {
     /// Resets the VM context by setting all registers to zero.
     ///
-    /// This method allows the `VmContext` instance to be reused by resetting
+    /// This method allows the `GuestSystemRegisters` instance to be reused by resetting
     /// its state to the default values (all zeros).
     pub fn reset(&mut self) {
-        self.cntvoff_el2 = 0;
-        self.cntp_cval_el0 = 0;
-        self.cntv_cval_el0 = 0;
-        self.cntp_tval_el0 = 0;
-        self.cntv_tval_el0 = 0;
-        self.cntkctl_el1 = 0;
-        self.cntvct_el0 = 0;
-        self.cntp_ctl_el0 = 0;
-        self.vpidr_el2 = 0;
-        self.vmpidr_el2 = 0;
-        self.sp_el0 = 0;
-        self.sp_el1 = 0;
-        self.elr_el1 = 0;
-        self.spsr_el1 = 0;
-        self.sctlr_el1 = 0;
-        self.actlr_el1 = 0;
-        self.cpacr_el1 = 0;
-        self.ttbr0_el1 = 0;
-        self.ttbr1_el1 = 0;
-        self.tcr_el1 = 0;
-        self.esr_el1 = 0;
-        self.far_el1 = 0;
-        self.par_el1 = 0;
-        self.mair_el1 = 0;
-        self.amair_el1 = 0;
-        self.vbar_el1 = 0;
-        self.contextidr_el1 = 0;
-        self.tpidr_el0 = 0;
-        self.tpidr_el1 = 0;
-        self.tpidrro_el0 = 0;
-        self.hcr_el2 = 0;
-        self.cptr_el2 = 0;
-        self.hstr_el2 = 0;
-        self.far_el2 = 0;
-        self.hpfar_el2 = 0;
+        *self = GuestSystemRegisters::default()
     }
 
-    /// Stores the current values of all relevant registers into the `VmContext` structure.
+    /// Stores the current values of all relevant registers into the `GuestSystemRegisters` structure.
     ///
     /// This method uses inline assembly to read the values of various system registers
-    /// and stores them in the corresponding fields of the `VmContext` structure.
-    pub fn ext_regs_store(&mut self) {
-        unsafe {
-            asm!("mrs {0}, CNTVOFF_EL2", out(reg) self.cntvoff_el2);
-            asm!("mrs {0}, CNTV_CVAL_EL0", out(reg) self.cntv_cval_el0);
-            asm!("mrs {0:x}, CNTKCTL_EL1", out(reg) self.cntkctl_el1);
-            asm!("mrs {0:x}, CNTP_CTL_EL0", out(reg) self.cntp_ctl_el0);
-            asm!("mrs {0:x}, CNTV_CTL_EL0", out(reg) self.cntv_ctl_el0);
-            asm!("mrs {0:x}, CNTP_TVAL_EL0", out(reg) self.cntp_tval_el0);
-            asm!("mrs {0:x}, CNTV_TVAL_EL0", out(reg) self.cntv_tval_el0);
-            asm!("mrs {0}, CNTVCT_EL0", out(reg) self.cntvct_el0);
-            // MRS!("self.vpidr_el2, VPIDR_EL2, "x");
-            asm!("mrs {0}, VMPIDR_EL2", out(reg) self.vmpidr_el2);
+    /// and stores them in the corresponding fields of the `GuestSystemRegisters` structure.
+    pub unsafe fn store(&mut self) {
+        asm!("mrs {0}, CNTVOFF_EL2", out(reg) self.cntvoff_el2);
+        asm!("mrs {0}, CNTV_CVAL_EL0", out(reg) self.cntv_cval_el0);
+        asm!("mrs {0:x}, CNTKCTL_EL1", out(reg) self.cntkctl_el1);
+        asm!("mrs {0:x}, CNTP_CTL_EL0", out(reg) self.cntp_ctl_el0);
+        asm!("mrs {0:x}, CNTV_CTL_EL0", out(reg) self.cntv_ctl_el0);
+        asm!("mrs {0:x}, CNTP_TVAL_EL0", out(reg) self.cntp_tval_el0);
+        asm!("mrs {0:x}, CNTV_TVAL_EL0", out(reg) self.cntv_tval_el0);
+        asm!("mrs {0}, CNTVCT_EL0", out(reg) self.cntvct_el0);
+        // MRS!("self.vpidr_el2, VPIDR_EL2, "x");
+        asm!("mrs {0}, VMPIDR_EL2", out(reg) self.vmpidr_el2);
 
-            asm!("mrs {0}, SP_EL0", out(reg) self.sp_el0);
-            asm!("mrs {0}, SP_EL1", out(reg) self.sp_el1);
-            asm!("mrs {0}, ELR_EL1", out(reg) self.elr_el1);
-            asm!("mrs {0:x}, SPSR_EL1", out(reg) self.spsr_el1);
-            asm!("mrs {0:x}, SCTLR_EL1", out(reg) self.sctlr_el1);
-            asm!("mrs {0:x}, CPACR_EL1", out(reg) self.cpacr_el1);
-            asm!("mrs {0}, TTBR0_EL1", out(reg) self.ttbr0_el1);
-            asm!("mrs {0}, TTBR1_EL1", out(reg) self.ttbr1_el1);
-            asm!("mrs {0}, TCR_EL1", out(reg) self.tcr_el1);
-            asm!("mrs {0:x}, ESR_EL1", out(reg) self.esr_el1);
-            asm!("mrs {0}, FAR_EL1", out(reg) self.far_el1);
-            asm!("mrs {0}, PAR_EL1", out(reg) self.par_el1);
-            asm!("mrs {0}, MAIR_EL1", out(reg) self.mair_el1);
-            asm!("mrs {0}, AMAIR_EL1", out(reg) self.amair_el1);
-            asm!("mrs {0}, VBAR_EL1", out(reg) self.vbar_el1);
-            asm!("mrs {0:x}, CONTEXTIDR_EL1", out(reg) self.contextidr_el1);
-            asm!("mrs {0}, TPIDR_EL0", out(reg) self.tpidr_el0);
-            asm!("mrs {0}, TPIDR_EL1", out(reg) self.tpidr_el1);
-            asm!("mrs {0}, TPIDRRO_EL0", out(reg) self.tpidrro_el0);
+        asm!("mrs {0}, SP_EL0", out(reg) self.sp_el0);
+        asm!("mrs {0}, SP_EL1", out(reg) self.sp_el1);
+        asm!("mrs {0}, ELR_EL1", out(reg) self.elr_el1);
+        asm!("mrs {0:x}, SPSR_EL1", out(reg) self.spsr_el1);
+        asm!("mrs {0:x}, SCTLR_EL1", out(reg) self.sctlr_el1);
+        asm!("mrs {0:x}, CPACR_EL1", out(reg) self.cpacr_el1);
+        asm!("mrs {0}, TTBR0_EL1", out(reg) self.ttbr0_el1);
+        asm!("mrs {0}, TTBR1_EL1", out(reg) self.ttbr1_el1);
+        asm!("mrs {0}, TCR_EL1", out(reg) self.tcr_el1);
+        asm!("mrs {0:x}, ESR_EL1", out(reg) self.esr_el1);
+        asm!("mrs {0}, FAR_EL1", out(reg) self.far_el1);
+        asm!("mrs {0}, PAR_EL1", out(reg) self.par_el1);
+        asm!("mrs {0}, MAIR_EL1", out(reg) self.mair_el1);
+        asm!("mrs {0}, AMAIR_EL1", out(reg) self.amair_el1);
+        asm!("mrs {0}, VBAR_EL1", out(reg) self.vbar_el1);
+        asm!("mrs {0:x}, CONTEXTIDR_EL1", out(reg) self.contextidr_el1);
+        asm!("mrs {0}, TPIDR_EL0", out(reg) self.tpidr_el0);
+        asm!("mrs {0}, TPIDR_EL1", out(reg) self.tpidr_el1);
+        asm!("mrs {0}, TPIDRRO_EL0", out(reg) self.tpidrro_el0);
 
-            asm!("mrs {0}, PMCR_EL0", out(reg) self.pmcr_el0);
-            asm!("mrs {0}, VTCR_EL2", out(reg) self.vtcr_el2);
-            asm!("mrs {0}, VTTBR_EL2", out(reg) self.vttbr_el2);
-            asm!("mrs {0}, HCR_EL2", out(reg) self.hcr_el2);
-            asm!("mrs {0}, ACTLR_EL1", out(reg) self.actlr_el1);
-        }
+        asm!("mrs {0}, PMCR_EL0", out(reg) self.pmcr_el0);
+        asm!("mrs {0}, VTCR_EL2", out(reg) self.vtcr_el2);
+        asm!("mrs {0}, VTTBR_EL2", out(reg) self.vttbr_el2);
+        asm!("mrs {0}, HCR_EL2", out(reg) self.hcr_el2);
+        asm!("mrs {0}, ACTLR_EL1", out(reg) self.actlr_el1);
         // println!("save sctlr {:x}", self.sctlr_el1);
     }
 
-    /// Restores the values of all relevant system registers from the `VmContext` structure.
+    /// Restores the values of all relevant system registers from the `GuestSystemRegisters` structure.
     ///
-    /// This method uses inline assembly to write the values stored in the `VmContext` structure
+    /// This method uses inline assembly to write the values stored in the `GuestSystemRegisters` structure
     /// back to the system registers. This is essential for restoring the state of a virtual machine
     /// or thread during context switching.
     ///
-    /// Each system register is restored with its corresponding value from the `VmContext`, ensuring
+    /// Each system register is restored with its corresponding value from the `GuestSystemRegisters`, ensuring
     /// that the virtual machine or thread resumes execution with the correct context.
-    pub unsafe fn ext_regs_restore(&self) {
+    pub unsafe fn restore(&self) {
         asm!("msr CNTV_CVAL_EL0, {0}", in(reg) self.cntv_cval_el0);
         asm!("msr CNTKCTL_EL1, {0:x}", in (reg) self.cntkctl_el1);
         asm!("msr CNTV_CTL_EL0, {0:x}", in (reg) self.cntv_ctl_el0);

--- a/src/context_frame.rs
+++ b/src/context_frame.rs
@@ -388,39 +388,37 @@ impl VmContext {
     ///
     /// Each system register is restored with its corresponding value from the `VmContext`, ensuring
     /// that the virtual machine or thread resumes execution with the correct context.
-    pub fn ext_regs_restore(&self) {
-        unsafe {
-            asm!("msr CNTV_CVAL_EL0, {0}", in(reg) self.cntv_cval_el0);
-            asm!("msr CNTKCTL_EL1, {0:x}", in (reg) self.cntkctl_el1);
-            asm!("msr CNTV_CTL_EL0, {0:x}", in (reg) self.cntv_ctl_el0);
-            asm!("msr SP_EL0, {0}", in(reg) self.sp_el0);
-            asm!("msr SP_EL1, {0}", in(reg) self.sp_el1);
-            asm!("msr ELR_EL1, {0}", in(reg) self.elr_el1);
-            asm!("msr SPSR_EL1, {0:x}", in(reg) self.spsr_el1);
-            asm!("msr SCTLR_EL1, {0:x}", in(reg) self.sctlr_el1);
-            asm!("msr CPACR_EL1, {0:x}", in(reg) self.cpacr_el1);
-            asm!("msr TTBR0_EL1, {0}", in(reg) self.ttbr0_el1);
-            asm!("msr TTBR1_EL1, {0}", in(reg) self.ttbr1_el1);
-            asm!("msr TCR_EL1, {0}", in(reg) self.tcr_el1);
-            asm!("msr ESR_EL1, {0:x}", in(reg) self.esr_el1);
-            asm!("msr FAR_EL1, {0}", in(reg) self.far_el1);
-            asm!("msr PAR_EL1, {0}", in(reg) self.par_el1);
-            asm!("msr MAIR_EL1, {0}", in(reg) self.mair_el1);
-            asm!("msr AMAIR_EL1, {0}", in(reg) self.amair_el1);
-            asm!("msr VBAR_EL1, {0}", in(reg) self.vbar_el1);
-            asm!("msr CONTEXTIDR_EL1, {0:x}", in(reg) self.contextidr_el1);
-            asm!("msr TPIDR_EL0, {0}", in(reg) self.tpidr_el0);
-            asm!("msr TPIDR_EL1, {0}", in(reg) self.tpidr_el1);
-            asm!("msr TPIDRRO_EL0, {0}", in(reg) self.tpidrro_el0);
+    pub unsafe fn ext_regs_restore(&self) {
+        asm!("msr CNTV_CVAL_EL0, {0}", in(reg) self.cntv_cval_el0);
+        asm!("msr CNTKCTL_EL1, {0:x}", in (reg) self.cntkctl_el1);
+        asm!("msr CNTV_CTL_EL0, {0:x}", in (reg) self.cntv_ctl_el0);
+        asm!("msr SP_EL0, {0}", in(reg) self.sp_el0);
+        asm!("msr SP_EL1, {0}", in(reg) self.sp_el1);
+        asm!("msr ELR_EL1, {0}", in(reg) self.elr_el1);
+        asm!("msr SPSR_EL1, {0:x}", in(reg) self.spsr_el1);
+        asm!("msr SCTLR_EL1, {0:x}", in(reg) self.sctlr_el1);
+        asm!("msr CPACR_EL1, {0:x}", in(reg) self.cpacr_el1);
+        asm!("msr TTBR0_EL1, {0}", in(reg) self.ttbr0_el1);
+        asm!("msr TTBR1_EL1, {0}", in(reg) self.ttbr1_el1);
+        asm!("msr TCR_EL1, {0}", in(reg) self.tcr_el1);
+        asm!("msr ESR_EL1, {0:x}", in(reg) self.esr_el1);
+        asm!("msr FAR_EL1, {0}", in(reg) self.far_el1);
+        asm!("msr PAR_EL1, {0}", in(reg) self.par_el1);
+        asm!("msr MAIR_EL1, {0}", in(reg) self.mair_el1);
+        asm!("msr AMAIR_EL1, {0}", in(reg) self.amair_el1);
+        asm!("msr VBAR_EL1, {0}", in(reg) self.vbar_el1);
+        asm!("msr CONTEXTIDR_EL1, {0:x}", in(reg) self.contextidr_el1);
+        asm!("msr TPIDR_EL0, {0}", in(reg) self.tpidr_el0);
+        asm!("msr TPIDR_EL1, {0}", in(reg) self.tpidr_el1);
+        asm!("msr TPIDRRO_EL0, {0}", in(reg) self.tpidrro_el0);
 
-            asm!("msr PMCR_EL0, {0}", in(reg) self.pmcr_el0);
-            asm!("msr ACTLR_EL1, {0}", in(reg) self.actlr_el1);
+        asm!("msr PMCR_EL0, {0}", in(reg) self.pmcr_el0);
+        asm!("msr ACTLR_EL1, {0}", in(reg) self.actlr_el1);
 
-            asm!("msr VTCR_EL2, {0}", in(reg) self.vtcr_el2);
-            asm!("msr VTTBR_EL2, {0}", in(reg) self.vttbr_el2);
-            asm!("msr HCR_EL2, {0}", in(reg) self.hcr_el2);
-            asm!("msr VMPIDR_EL2, {0}", in(reg) self.vmpidr_el2);
-            asm!("msr CNTVOFF_EL2, {0}", in(reg) self.cntvoff_el2);
-        }
+        asm!("msr VTCR_EL2, {0}", in(reg) self.vtcr_el2);
+        asm!("msr VTTBR_EL2, {0}", in(reg) self.vttbr_el2);
+        asm!("msr HCR_EL2, {0}", in(reg) self.hcr_el2);
+        asm!("msr VMPIDR_EL2, {0}", in(reg) self.vmpidr_el2);
+        asm!("msr CNTVOFF_EL2, {0}", in(reg) self.cntvoff_el2);
     }
 }

--- a/src/context_frame.rs
+++ b/src/context_frame.rs
@@ -17,12 +17,8 @@ use aarch64_cpu::registers::*;
 pub struct Aarch64ContextFrame {
     /// An array of 31 `u64` values representing the general-purpose registers.
     pub gpr: [u64; 31],
-    /// The stack pointer of EL0, i.e., the `sp_el0` register.
-    ///
-    /// Even though the stack pointer is automatically saved into and restored from `sp_el0` by the hardware,
-    /// several OSes and hypervisors utilize this register as a thread-local storage pointer (to store the
-    /// pointer to `current_task` generally), which requires the stack pointer to be saved and restored
-    /// during context switches.
+    /// The stack pointer.
+    /// The value currently stored in this field is meaningless (the base address of Aarch64ContextFrame).
     pub sp: u64,
     /// The exception link register, which stores the return address after an exception.
     pub elr: u64,

--- a/src/entry.S
+++ b/src/entry.S
@@ -10,12 +10,6 @@ context_vm_entry:
     msr     elr_el2, x10
     msr     spsr_el2, x11
 
-    # Swap `sp_el0` with `Aarch64VCpu.ctx`'s `sp`
-    ldr     x10,      [sp, 31 * 8]
-    mrs     x11, sp_el0
-    msr     sp_el0, x10
-    str     x11,      [sp, 31 * 8]
-
     # Restore saved general purpose registers from `Aarch64VCpu.ctx`
     ldr     x30,      [sp, 30 * 8]
     ldp     x28, x29, [sp, 28 * 8]

--- a/src/exception.S
+++ b/src/exception.S
@@ -17,13 +17,11 @@
     stp     x24, x25, [sp, 24 * 8]
     stp     x26, x27, [sp, 26 * 8]
     stp     x28, x29, [sp, 28 * 8]
-    str     x30,      [sp, 30 * 8]
 
-    # Swap `sp_el0` with `Aarch64VCpu.ctx`'s `sp`
-    ldr     x10,      [sp, 31 * 8]
-    mrs     x11, sp_el0
-    msr     sp_el0, x10
-    str     x11,      [sp, 31 * 8]
+    # The value currently stored in `sp` is unused, (the base address of Aarch64ContextFrame).
+    mov     x9, sp
+    add     x9, x9, #(0x110)
+    stp     x30, x9, [sp, 30 * 8]
 
     # Save `elr_el2` and `spsr_el2` into `Aarch64VCpu.ctx`
     mrs     x10, elr_el2

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -28,7 +28,7 @@ impl AxArchPerCpu for Aarch64PerCpu {
 
     fn is_enabled(&self) -> bool {
         let hcr_el2 = HCR_EL2.get();
-        return hcr_el2 & 1 != 0;
+        hcr_el2 & 1 != 0
     }
 
     fn hardware_enable(&mut self) -> AxResult {
@@ -41,7 +41,8 @@ impl AxArchPerCpu for Aarch64PerCpu {
         // defined in this crate.
         VBAR_EL2.set(exception_vector_base_vcpu as usize as _);
 
-        Ok(HCR_EL2.set(HCR_EL2::VM::Enable.into()))
+        HCR_EL2.set(HCR_EL2::VM::Enable.into());
+        Ok(())
     }
 
     fn hardware_disable(&mut self) -> AxResult {
@@ -50,6 +51,7 @@ impl AxArchPerCpu for Aarch64PerCpu {
         // Todo: take care of `preemption`
         VBAR_EL2.set(unsafe { ORI_EXCEPTION_VECTOR_BASE.read_current_raw() } as _);
 
-        Ok(HCR_EL2.set(HCR_EL2::VM::Disable.into()))
+        HCR_EL2.set(HCR_EL2::VM::Disable.into());
+        Ok(())
     }
 }

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -5,7 +5,7 @@ use axaddrspace::{GuestPhysAddr, HostPhysAddr};
 use axerrno::AxResult;
 use axvcpu::AxVCpuExitReason;
 
-use crate::context_frame::VmContext;
+use crate::context_frame::GuestSystemRegisters;
 use crate::exception::{handle_exception_irq, handle_exception_sync, TrapKind};
 use crate::exception_utils::exception_class_value;
 use crate::TrapFrame;
@@ -15,12 +15,14 @@ core::arch::global_asm!(include_str!("entry.S"));
 #[percpu::def_percpu]
 static HOST_SP_EL0: u64 = 0;
 
-fn save_host_sp_el0() {
-    unsafe { HOST_SP_EL0.write_current_raw(SP_EL0.get()) }
+/// Save host's `SP_EL0` to the current percpu region.
+unsafe fn save_host_sp_el0() {
+    HOST_SP_EL0.write_current_raw(SP_EL0.get())
 }
 
-fn restore_host_sp_el0() {
-    SP_EL0.set(unsafe { HOST_SP_EL0.read_current_raw() });
+/// Restore host's `SP_EL0` from the current percpu region.
+unsafe fn restore_host_sp_el0() {
+    SP_EL0.set(HOST_SP_EL0.read_current_raw());
 }
 
 /// (v)CPU register state that must be saved or restored when entering/exiting a VM or switching
@@ -31,17 +33,7 @@ pub struct VmCpuRegisters {
     /// guest trap context
     pub trap_context_regs: TrapFrame,
     /// virtual machine system regs setting
-    pub vm_system_regs: VmContext,
-}
-
-impl VmCpuRegisters {
-    /// create a default VmCpuRegisters
-    pub fn default() -> VmCpuRegisters {
-        VmCpuRegisters {
-            trap_context_regs: TrapFrame::default(),
-            vm_system_regs: VmContext::default(),
-        }
-    }
+    pub vm_system_regs: GuestSystemRegisters,
 }
 
 /// A virtual CPU within a guest
@@ -52,7 +44,7 @@ pub struct Aarch64VCpu {
     // DO NOT add anything before or between them unless you do know what you are doing!
     ctx: TrapFrame,
     host_stack_top: u64,
-    system_regs: VmContext,
+    guest_system_regs: GuestSystemRegisters,
     vcpu_id: usize,
 }
 
@@ -68,14 +60,12 @@ impl axvcpu::AxArchVCpu for Aarch64VCpu {
         Ok(Self {
             ctx: TrapFrame::default(),
             host_stack_top: 0,
-            system_regs: VmContext::default(),
+            guest_system_regs: GuestSystemRegisters::default(),
             vcpu_id: 0, // need to pass a parameter!!!!
         })
     }
 
     fn setup(&mut self, _config: Self::SetupConfig) -> AxResult {
-        // do_register_lower_aarch64_synchronous_handler()?;
-        // do_register_lower_aarch64_irq_handler()?;
         self.init_hv();
         Ok(())
     }
@@ -88,18 +78,22 @@ impl axvcpu::AxArchVCpu for Aarch64VCpu {
 
     fn set_ept_root(&mut self, ept_root: HostPhysAddr) -> AxResult {
         debug!("set vcpu ept root:{:#x}", ept_root);
-        self.system_regs.vttbr_el2 = ept_root.as_usize() as u64;
+        self.guest_system_regs.vttbr_el2 = ept_root.as_usize() as u64;
         Ok(())
     }
 
     fn run(&mut self) -> AxResult<AxVCpuExitReason> {
-        // Save host SP_EL0 to the ctx becase it's used as current task ptr.
-        // This has to be done before vm system regs are restored.
-        save_host_sp_el0();
-        self.restore_vm_system_regs();
-        let exit_reason =
-            TrapKind::try_from(unsafe { self.run_guest() } as u8).expect("Invalid TrapKind");
-        self.vmexit_handler(exit_reason)
+        // Run guest.
+        let exit_reson = unsafe {
+            // Save host SP_EL0 to the ctx becase it's used as current task ptr.
+            // This has to be done before vm system regs are restored.
+            save_host_sp_el0();
+            self.restore_vm_system_regs();
+            self.run_guest()
+        };
+
+        let trap_kind = TrapKind::try_from(exit_reson as u8).expect("Invalid TrapKind");
+        self.vmexit_handler(trap_kind)
     }
 
     fn bind(&mut self) -> AxResult {
@@ -136,24 +130,22 @@ impl Aarch64VCpu {
         0
     }
 
-    fn restore_vm_system_regs(&mut self) {
-        unsafe {
-            // load system regs
-            core::arch::asm!(
-                "
-                mov x3, xzr           // Trap nothing from EL1 to El2.
-                msr cptr_el2, x3"
-            );
-            self.system_regs.ext_regs_restore();
-            core::arch::asm!(
-                "
-                ic  iallu
-                tlbi	alle2
-                tlbi	alle1         // Flush tlb
-                dsb	nsh
-                isb"
-            );
-        }
+    unsafe fn restore_vm_system_regs(&mut self) {
+        // load system regs
+        core::arch::asm!(
+            "
+            mov x3, xzr           // Trap nothing from EL1 to El2.
+            msr cptr_el2, x3"
+        );
+        self.guest_system_regs.restore();
+        core::arch::asm!(
+            "
+            ic  iallu
+            tlbi	alle2
+            tlbi	alle1         // Flush tlb
+            dsb	nsh
+            isb"
+        );
     }
 
     fn vmexit_handler(&mut self, exit_reason: TrapKind) -> AxResult<AxVCpuExitReason> {
@@ -162,16 +154,18 @@ impl Aarch64VCpu {
             exception_class_value(),
             self.ctx
         );
-        // store system regs
-        self.system_regs.ext_regs_store();
-        // restore host SP_EL0.
-        // This has to be done after guest's SP_EL0 is stored by `ext_regs_store`.
-        restore_host_sp_el0();
 
-        let ctx = &mut self.ctx;
+        unsafe {
+            // Store guest system regs
+            self.guest_system_regs.store();
+            // Restore host SP_EL0.
+            // This has to be done after guest's SP_EL0 is stored by `ext_regs_store`.
+            restore_host_sp_el0();
+        }
+
         match exit_reason {
-            TrapKind::Synchronous => handle_exception_sync(ctx),
-            TrapKind::Irq => handle_exception_irq(ctx),
+            TrapKind::Synchronous => handle_exception_sync(&mut self.ctx),
+            TrapKind::Irq => handle_exception_irq(&mut self.ctx),
             _ => panic!("Unhandled exception {:?}", exit_reason),
         }
     }
@@ -189,12 +183,12 @@ impl Aarch64VCpu {
     /// Init guest context. Also set some el2 register value.
     fn init_vm_context(&mut self) {
         CNTHCTL_EL2.modify(CNTHCTL_EL2::EL1PCEN::SET + CNTHCTL_EL2::EL1PCTEN::SET);
-        self.system_regs.cntvoff_el2 = 0;
-        self.system_regs.cntkctl_el1 = 0;
+        self.guest_system_regs.cntvoff_el2 = 0;
+        self.guest_system_regs.cntkctl_el1 = 0;
 
-        self.system_regs.sctlr_el1 = 0x30C50830;
-        self.system_regs.pmcr_el0 = 0;
-        self.system_regs.vtcr_el2 = (VTCR_EL2::PS::PA_40B_1TB
+        self.guest_system_regs.sctlr_el1 = 0x30C50830;
+        self.guest_system_regs.pmcr_el0 = 0;
+        self.guest_system_regs.vtcr_el2 = (VTCR_EL2::PS::PA_40B_1TB
             + VTCR_EL2::TG0::Granule4KB
             + VTCR_EL2::SH0::Inner
             + VTCR_EL2::ORGN0::NormalWBRAWA
@@ -202,7 +196,7 @@ impl Aarch64VCpu {
             + VTCR_EL2::SL0.val(0b01)
             + VTCR_EL2::T0SZ.val(64 - 39))
         .into();
-        self.system_regs.hcr_el2 = (HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64).into();
+        self.guest_system_regs.hcr_el2 = (HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64).into();
         // self.system_regs.hcr_el2 |= 1<<27;
         // + HCR_EL2::IMO::EnableVirtualIRQ).into();
         // trap el1 smc to el2
@@ -211,7 +205,7 @@ impl Aarch64VCpu {
         let mut vmpidr = 0;
         vmpidr |= 1 << 31;
         vmpidr |= self.vcpu_id;
-        self.system_regs.vmpidr_el2 = vmpidr as u64;
+        self.guest_system_regs.vmpidr_el2 = vmpidr as u64;
     }
 
     /// Set exception return pc


### PR DESCRIPTION
### BUG decription

There is a bug in current solution of the maintenance of SP_EL0 belonging to host ArceOS, which is used to store the current task pointer.

That is, we save the host's sp_el0 in a wrong place: after `restore_vm_system_regs`, where guest's sp_el0 is already write to sp_el0 register.

As a result, host save a polluted sp_el0, which is already modified by `restore_vm_system_regs`.

It will cause a panic when you try to get current task’s pointer during VM-Exit handling.

```Rust
[  0.467056 0 axruntime::lang_items:5] panicked at /home/hky/.cargo/git/checkouts/arceos-8d7257a02b016867/d4cf00a/modules/axtask/src/task.rs:385:25:
current task is uninitialized
```

### Solution

use percpu region to maintain the correct SP_EL0 belonging to host ArceOS.

```Rust
#[percpu::def_percpu]
static HOST_SP_EL0: u64 = 0;

fn save_host_sp_el0() {
    unsafe { HOST_SP_EL0.write_current_raw(SP_EL0.get()) }
}

fn restore_host_sp_el0() {
    SP_EL0.set(unsafe { HOST_SP_EL0.read_current_raw() });
}
```