### PR TITLE
fix(vcpu): correct exit reason handling in vmexit trampoline

### DIFF
--- a/src/exception.rs
+++ b/src/exception.rs
@@ -263,14 +263,14 @@ fn dispatch_irq() {
 #[no_mangle]
 unsafe extern "C" fn vmexit_trampoline() {
     core::arch::asm!(
-        "mov x6, x0", // Save the exit reason.
+        "mov x9, x0", // Save the exit reason.
         "bl {vcpu_running}", // Check if vcpu is running.
-        "mov x7, x0", // Save the return value of vcpu_running.
-        "mov x0, x6", // Restore the exit reason.
+        "mov x10, x0", // Save the return value of vcpu_running.
+        "mov x0, x9", // Restore the exit reason.
         // If vcpu_running returns true, jump to `return_run_guest`,
         // after that the control flow is handed back to Aarch64VCpu.run(),
         // simulating the normal return of the `run_guest` function.
-        "cbnz x7, {return_run_guest}",
+        "cbnz x10, {return_run_guest}",
         // If vcpu_running returns false, there is no active vcpu running,
         // jump to `dispatch_irq`.
         "bl {dispatch_irq}",

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -263,11 +263,14 @@ fn dispatch_irq() {
 #[no_mangle]
 unsafe extern "C" fn vmexit_trampoline() {
     core::arch::asm!(
+        "mov x6, x0", // Save the exit reason.
         "bl {vcpu_running}", // Check if vcpu is running.
+        "mov x7, x0", // Save the return value of vcpu_running.
+        "mov x0, x6", // Restore the exit reason.
         // If vcpu_running returns true, jump to `return_run_guest`,
         // after that the control flow is handed back to Aarch64VCpu.run(),
         // simulating the normal return of the `run_guest` function.
-        "cbnz x0, {return_run_guest}",
+        "cbnz x7, {return_run_guest}",
         // If vcpu_running returns false, there is no active vcpu running,
         // jump to `dispatch_irq`.
         "bl {dispatch_irq}",

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -222,8 +222,14 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
             options(nostack)
         );
 
-        // the dummy return value, the real return value is in x0 when `return_run_guest` returns
-        0
+        // Return value is the exit reason, the real return value is in x0 when `return_run_guest` returns
+        let exit_reason: usize;
+        core::arch::asm!(
+            "mov {}, x0",
+            out(reg) exit_reason,
+            options(nostack)
+        );
+        exit_reason
     }
 
     /// Restores guest system control registers.


### PR DESCRIPTION
- Update vmexit_trampoline to properly save and restore exit reason
- Modify Aarch64VCpu::run to return exit reason instead of dummy value
- These changes ensure correct handling of VM exits and improve code clarity