### PR TITLE
fix(vcpu): correct return value handling for run_guest function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links -D missing-docs
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@nightly-2024-12-25
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links -D missing-docs
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@stable
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
       RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links -D missing-docs
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly-2024-12-25
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        toolchain: nightly-2024-12-25
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: |

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -324,7 +324,7 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
 ///
 /// - This function is not typically called directly from Rust code. Instead, it is
 ///   invoked as part of the low-level hypervisor or VM exit handling routines.
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 unsafe extern "C" fn vmexit_trampoline() -> ! {
     unsafe {

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -324,7 +324,7 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
 ///
 /// - This function is not typically called directly from Rust code. Instead, it is
 ///   invoked as part of the low-level hypervisor or VM exit handling routines.
-#[unsafe(naked)]
+#[naked]
 #[unsafe(no_mangle)]
 unsafe extern "C" fn vmexit_trampoline() -> ! {
     unsafe {

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -205,7 +205,7 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
         // When `vmexit_trampoline` returns, it will come back here, with its return value stored in x0. Extract it and return `run_guest`.
         // Related PR: https://github.com/arceos-hypervisor/arm_vcpu/pull/26
         // Related issue: https://github.com/arceos-hypervisor/arm_vcpu/issues/22
-        // This is a temporary workaround for the issue. 
+        // This is a temporary workaround for the issue.
         let exit_reason: usize;
         unsafe {
             core::arch::asm!(

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -203,6 +203,9 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
         }
 
         // When `vmexit_trampoline` returns, it will come back here, with its return value stored in x0. Extract it and return `run_guest`.
+        // Related PR: https://github.com/arceos-hypervisor/arm_vcpu/pull/26
+        // Related issue: https://github.com/arceos-hypervisor/arm_vcpu/issues/22
+        // This is a temporary workaround for the issue. 
         let exit_reason: usize;
         unsafe {
             core::arch::asm!(

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -208,7 +208,7 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
             core::arch::asm!(
                 "mov {}, x0",
                 out(reg) exit_reason
-            );            
+            );
         }
         exit_reason
     }

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -202,8 +202,15 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
             );
         }
 
-        // the dummy return value, the real return value is in x0 when `return_run_guest` returns
-        0
+        // When `vmexit_trampoline` returns, it will come back here, with its return value stored in x0. Extract it and return `run_guest`.
+        let exit_reason: usize;
+        unsafe {
+            core::arch::asm!(
+                "mov {}, x0",
+                out(reg) exit_reason
+            );            
+        }
+        exit_reason
     }
 
     /// Restores guest system control registers.


### PR DESCRIPTION
#22 

- Update the `run_guest` function to properly handle the return value from `vmexit_trampoline`
- Use inline assembly to extract the exit reason from x0 register
- Return the extracted exit reason instead of a dummy value 