### PR TITLE
refactor: `AccessWidth` is defined redundantly in both axvcpu and axa…

### DIFF
--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,8 +1,8 @@
 use aarch64_cpu::registers::{ESR_EL2, HCR_EL2, Readable, SCTLR_EL1, VTCR_EL2, VTTBR_EL2};
 
-use axaddrspace::GuestPhysAddr;
+use axaddrspace::{GuestPhysAddr, device::AccessWidth};
 use axerrno::{AxError, AxResult};
-use axvcpu::{AccessWidth, AxVCpuExitReason};
+use axvcpu::AxVCpuExitReason;
 
 use crate::TrapFrame;
 use crate::exception_utils::{

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,6 +1,7 @@
 use aarch64_cpu::registers::{ESR_EL2, HCR_EL2, Readable, SCTLR_EL1, VTCR_EL2, VTTBR_EL2};
 
-use axaddrspace::{GuestPhysAddr, device::AccessWidth};
+use axaddrspace::GuestPhysAddr;
+use axaddrspace::device::AccessWidth;
 use axerrno::{AxError, AxResult};
 use axvcpu::AxVCpuExitReason;
 


### PR DESCRIPTION
 …ddrspace. Remove it from axvcpu.

Rely on the following PRs
[axvcpu](https://github.com/arceos-hypervisor/axvcpu/pull/26)
[arm_vcpu](https://github.com/arceos-hypervisor/arm_vcpu/pull/30)
[x86_vcpu](https://github.com/arceos-hypervisor/x86_vcpu/pull/17)