### PR TITLE
refactor: adapt axvm refactor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "aarch64-unknown-none-softfloat"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,16 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly-2024-12-25
+        toolchain: nightly-2025-05-20
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: |
         cargo doc --no-deps --all-features
-        printf '<meta http-equiv="refresh" content="0;url=%s/index.html">' $(cargo tree | head -1 | cut -d' ' -f1) > target/doc/index.html
+        printf '<meta http-equiv="refresh" content="0;url=%s/index.html">' $(cargo tree | head -1 | cut -d' ' -f1) > target/aarch64-unknown-none-softfloat/doc/index.html
     - name: Deploy to Github Pages
       if: ${{ github.ref == env.default-branch }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         single-commit: true
         branch: gh-pages
-        folder: target/doc
+        folder: target/aarch64-unknown-none-softfloat/doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.1
+## 0.3.0
 
 - Support the new 4-level-ept feature. By default, level 3 ept is used. After enabling this feature, level 4 ept is used.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,3 @@ spin = "0.10"
 
 axerrno = "0.1.0"
 axvm-types.workspace = true
-percpu = {version = "0.2.0", features = ["arm-el2"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ spin = "0.10"
 
 aarch64-cpu = "11.0"
 numeric-enum-macro = "0.2"
+axvm-types.workspace = true
 
 axerrno = "0.1.0"
 percpu = {version = "0.2.0", features = ["arm-el2"]}
 
-axaddrspace = "0.2"
-axvcpu = "0.1.0"
-axvisor_api = "0.1.0"
+# axaddrspace = "0.2"
+# axvcpu = "0.1.0"
+# axvisor_api = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,6 @@ percpu = {version = "0.2.0", features = ["arm-el2"]}
 
 axaddrspace = "0.1"
 axdevice_base = "0.1.0"
-axvcpu = "0.1.0"
+axvcpu = {git="https://github.com/arceos-hypervisor/axvcpu.git", branch="next"}
+# axvcpu = "0.1.0"
 axvisor_api = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,12 @@ version = "0.1.1"
 log = "0.4"
 spin = "0.10"
 
-aarch64-cpu = "10.0"
+aarch64-cpu = "11.0"
 numeric-enum-macro = "0.2"
 
 axerrno = "0.1.0"
 percpu = {version = "0.2.0", features = ["arm-el2"]}
 
 axaddrspace = "0.2"
-axdevice_base = "0.1.0"
 axvcpu = "0.1.0"
 axvisor_api = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
-edition = "2024"
-name = "arm_vcpu"
-version = "0.1.1"
 authors = [
-    "KeYang Hu <keyang.hu@qq.com>",
-    "Mingxian Su <aarkegz@gmail.com>",
-    "ShiMei Tang <shimei820@gmail.com>",
-    "DeBin Luo <luodeb@outlook.com>",
-    "周睿 <zrufo747@outlook.com>"
+  "KeYang Hu <keyang.hu@qq.com>",
+  "Mingxian Su <aarkegz@gmail.com>",
+  "ShiMei Tang <shimei820@gmail.com>",
+  "DeBin Luo <luodeb@outlook.com>",
+  "周睿 <zrufo747@outlook.com>",
 ]
-description = "Aarch64 VCPU implementation for Arceos Hypervisor"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/arceos-hypervisor/arm_vcpu"
 categories = ["embedded", "no-std"]
+description = "Aarch64 VCPU implementation for Arceos Hypervisor"
+edition = "2024"
 keywords = ["hypervisor", "aarch64", "vcpu"]
-
-[features]
-4-level-ept = []
+license = "MIT OR Apache-2.0"
+name = "arm_vcpu"
+repository = "https://github.com/arceos-hypervisor/arm_vcpu"
+version = "0.1.1"
 
 [dependencies]
 log = "0.4"
@@ -24,7 +21,6 @@ spin = "0.10"
 
 aarch64-cpu = "10.0"
 numeric-enum-macro = "0.2"
-tock-registers = "0.9"
 
 axerrno = "0.1.0"
 percpu = {version = "0.2.0", features = ["arm-el2"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ numeric-enum-macro = "0.2"
 axerrno = "0.1.0"
 percpu = {version = "0.2.0", features = ["arm-el2"]}
 
-axaddrspace = "0.1"
+axaddrspace = "0.2"
 axdevice_base = "0.1.0"
-axvcpu = {git="https://github.com/arceos-hypervisor/axvcpu.git", branch="next"}
+axvcpu = {git = "https://github.com/arceos-hypervisor/axvcpu.git", branch = "next"}
 # axvcpu = "0.1.0"
 axvisor_api = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,11 @@ repository = "https://github.com/arceos-hypervisor/arm_vcpu"
 version = "0.1.1"
 
 [dependencies]
+aarch64-cpu = "11.0"
 log = "0.4"
+numeric-enum-macro = "0.2"
 spin = "0.10"
 
-aarch64-cpu = "11.0"
-numeric-enum-macro = "0.2"
-axvm-types.workspace = true
-
 axerrno = "0.1.0"
+axvm-types.workspace = true
 percpu = {version = "0.2.0", features = ["arm-el2"]}
-
-# axaddrspace = "0.2"
-# axvcpu = "0.1.0"
-# axvisor_api = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,5 @@ percpu = {version = "0.2.0", features = ["arm-el2"]}
 
 axaddrspace = "0.2"
 axdevice_base = "0.1.0"
-axvcpu = {git = "https://github.com/arceos-hypervisor/axvcpu.git", branch = "next"}
-# axvcpu = "0.1.0"
+axvcpu = "0.1.0"
 axvisor_api = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["hypervisor", "aarch64", "vcpu"]
 license = "MIT OR Apache-2.0"
 name = "arm_vcpu"
 repository = "https://github.com/arceos-hypervisor/arm_vcpu"
-version = "0.1.1"
+version = "0.3.0"
 
 [dependencies]
 aarch64-cpu = "11.0"
 log = "0.4"
 numeric-enum-macro = "0.2"
 spin = "0.10"
-
-axerrno = "0.1.0"
+thiserror = {version = "2", default-features = false}
+anyhow = {version = "1.0", default-features = false}
 axvm-types.workspace = true

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -340,7 +340,7 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
 ///   invoked as part of the low-level hypervisor or VM exit handling routines.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-unsafe extern fn vmexit_trampoline() -> ! {
+unsafe extern "C" fn vmexit_trampoline() -> ! {
     core::arch::naked_asm!(
         // Curretly `sp` points to the base address of `Aarch64VCpu.ctx`, which stores guest's `TrapFrame`.
         "add x9, sp, 34 * 8", // Skip the exception frame.

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -340,7 +340,7 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
 ///   invoked as part of the low-level hypervisor or VM exit handling routines.
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
-unsafe extern "C" fn vmexit_trampoline() -> ! {
+unsafe extern fn vmexit_trampoline() -> ! {
     core::arch::naked_asm!(
         // Curretly `sp` points to the base address of `Aarch64VCpu.ctx`, which stores guest's `TrapFrame`.
         "add x9, sp, 34 * 8", // Skip the exception frame.

--- a/src/exception_utils.rs
+++ b/src/exception_utils.rs
@@ -1,5 +1,5 @@
 use aarch64_cpu::registers::*;
-use axaddrspace::GuestPhysAddr;
+use axvm_types::addr::GuestPhysAddr;
 use axerrno::{AxResult, ax_err};
 
 /// Retrieves the Exception Syndrome Register (ESR) value from EL2.

--- a/src/exception_utils.rs
+++ b/src/exception_utils.rs
@@ -1,7 +1,6 @@
-use aarch64_cpu::registers::{ESR_EL2, FAR_EL2, PAR_EL1};
+use aarch64_cpu::registers::*;
 use axaddrspace::GuestPhysAddr;
 use axerrno::{AxResult, ax_err};
-use tock_registers::interfaces::*;
 
 /// Retrieves the Exception Syndrome Register (ESR) value from EL2.
 ///

--- a/src/exception_utils.rs
+++ b/src/exception_utils.rs
@@ -1,6 +1,6 @@
 use aarch64_cpu::registers::*;
-use axvm_types::addr::GuestPhysAddr;
 use axerrno::{AxResult, ax_err};
+use axvm_types::addr::GuestPhysAddr;
 
 /// Retrieves the Exception Syndrome Register (ESR) value from EL2.
 ///

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,7 +1,6 @@
 use axvm_types::{
     addr::GuestPhysAddr,
     device::{AccessWidth, SysRegAddr},
-    mem::MappingFlags,
 };
 
 /// Reasons for VM-Exits returned by [AxArchVCpu::run].

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,7 +1,4 @@
-use axvm_types::{
-    addr::GuestPhysAddr,
-    device::{AccessWidth, SysRegAddr},
-};
+use crate::{AccessWidth, GuestPhysAddr, SysRegAddr};
 
 /// Reasons for VM-Exits returned by [AxArchVCpu::run].
 ///

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,0 +1,192 @@
+use axvm_types::{
+    addr::GuestPhysAddr,
+    device::{AccessWidth, SysRegAddr},
+    mem::MappingFlags,
+};
+
+/// Reasons for VM-Exits returned by [AxArchVCpu::run].
+///
+/// When a guest virtual CPU executes, various conditions can cause control to be
+/// transferred back to the hypervisor. This enum represents all possible exit reasons
+/// that can occur during VCpu execution.
+///
+/// # VM Exit Categories
+///
+/// - **I/O Operations**: MMIO reads/writes, port I/O, system register access
+/// - **System Events**: Hypercalls, interrupts, nested page faults
+/// - **Power Management**: CPU power state changes, system shutdown
+/// - **Multiprocessing**: IPI sending, secondary CPU bring-up
+/// - **Error Conditions**: Entry failures, invalid states
+///
+/// # Compatibility Note
+///
+/// This enum draws inspiration from [kvm-ioctls](https://github.com/rust-vmm/kvm-ioctls/blob/main/src/ioctls/vcpu.rs)
+/// for consistency with existing virtualization frameworks.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum AxVCpuExitReason {
+    /// A guest instruction triggered a hypercall to the hypervisor.
+    ///
+    /// Hypercalls are a mechanism for the guest OS to request services from
+    /// the hypervisor, similar to system calls in a traditional OS.
+    Hypercall {
+        /// The hypercall number identifying the requested service
+        nr: u64,
+        /// Arguments passed to the hypercall (up to 6 parameters)
+        args: [u64; 6],
+    },
+
+    /// The guest performed a Memory-Mapped I/O (MMIO) read operation.
+    ///
+    /// MMIO reads occur when the guest accesses device registers or other
+    /// hardware-mapped memory regions that require hypervisor emulation.
+    MmioRead {
+        /// Guest physical address being read from
+        addr: GuestPhysAddr,
+        /// Width/size of the memory access (8, 16, 32, or 64 bits)
+        width: AccessWidth,
+        /// Index of the guest register that will receive the read value
+        reg: usize,
+        /// Width of the destination register  
+        reg_width: AccessWidth,
+        /// Whether to sign-extend the read value to fill the register
+        signed_ext: bool,
+    },
+
+    /// The guest performed a Memory-Mapped I/O (MMIO) write operation.
+    ///
+    /// MMIO writes occur when the guest writes to device registers or other
+    /// hardware-mapped memory regions that require hypervisor emulation.
+    MmioWrite {
+        /// Guest physical address being written to
+        addr: GuestPhysAddr,
+        /// Width/size of the memory access (8, 16, 32, or 64 bits)
+        width: AccessWidth,
+        /// Data being written to the memory location
+        data: u64,
+    },
+
+    /// The guest performed a system register read operation.
+    ///
+    /// System registers are architecture-specific control and status registers:
+    /// - **x86_64**: Model-Specific Registers (MSRs)
+    /// - **RISC-V**: Control and Status Registers (CSRs)
+    /// - **AArch64**: System registers accessible via MRS instruction
+    SysRegRead {
+        /// Address/identifier of the system register being read
+        ///
+        /// - **x86_64/RISC-V**: Direct register address
+        /// - **AArch64**: ESR_EL2.ISS format (`<op0><op2><op1><CRn>00000<CRm>0`)
+        ///   compatible with the `aarch64_sysreg` crate numbering scheme
+        addr: SysRegAddr,
+        /// Index of the guest register that will receive the read value
+        ///
+        /// **Note**: Unused on x86_64 where the result is always stored in `[edx:eax]`
+        reg: usize,
+    },
+
+    /// The guest performed a system register write operation.
+    ///
+    /// System registers are architecture-specific control and status registers:
+    /// - **x86_64**: Model-Specific Registers (MSRs)
+    /// - **RISC-V**: Control and Status Registers (CSRs)
+    /// - **AArch64**: System registers accessible via MSR instruction  
+    SysRegWrite {
+        /// Address/identifier of the system register being written
+        ///
+        /// - **x86_64/RISC-V**: Direct register address
+        /// - **AArch64**: ESR_EL2.ISS format (`<op0><op2><op1><CRn>00000<CRm>0`)
+        ///   compatible with the `aarch64_sysreg` crate numbering scheme
+        addr: SysRegAddr,
+        /// Data being written to the system register
+        value: u64,
+    },
+
+    /// An external interrupt was delivered to the VCpu.
+    ///
+    /// This represents hardware interrupts from external devices that need
+    /// to be processed by the guest or hypervisor.
+    ///
+    /// **Note**: This enum may be extended with additional fields in the future.
+    /// Use `..` in pattern matching to ensure forward compatibility.
+    ExternalInterrupt,
+
+    /// Request to bring up a secondary CPU core.
+    ///
+    /// This exit reason is used during the multi-core VM boot process when
+    /// the primary CPU requests that a secondary CPU be started. The specific
+    /// mechanism varies by architecture:
+    ///
+    /// - **ARM**: PSCI (Power State Coordination Interface) calls
+    /// - **x86**: SIPI (Startup Inter-Processor Interrupt)
+    /// - **RISC-V**: SBI (Supervisor Binary Interface) calls
+    CpuUp {
+        /// Target CPU identifier to be started
+        ///
+        /// Format varies by architecture:
+        /// - **AArch64**: MPIDR register affinity fields  
+        /// - **x86_64**: APIC ID of the target CPU
+        /// - **RISC-V**: Hart ID of the target CPU
+        target_cpu: u64,
+        /// Guest physical address where the secondary CPU should begin execution
+        entry_point: GuestPhysAddr,
+        /// Argument to pass to the secondary CPU
+        ///
+        /// - **AArch64**: Value to set in `x0` register at startup
+        /// - **RISC-V**: Value to set in `a1` register (`a0` gets the hartid)
+        /// - **x86_64**: Currently unused
+        arg: u64,
+    },
+
+    /// The guest VCpu has been powered down.
+    ///
+    /// This indicates the VCpu has executed a power-down instruction or
+    /// hypercall and should be suspended. The VCpu may be resumed later.
+    CpuDown {
+        /// Power state information (currently unused)
+        ///
+        /// Reserved for future use with PSCI_POWER_STATE or similar mechanisms
+        _state: u64,
+    },
+
+    /// The guest has requested system-wide shutdown.
+    ///
+    /// This indicates the entire virtual machine should be powered off,
+    /// not just the current VCpu.
+    SystemDown,
+
+    /// No special handling required - the VCpu handled the exit internally.
+    ///
+    /// This provides an opportunity for the hypervisor to:
+    /// - Check virtual device states
+    /// - Process pending interrupts  
+    /// - Handle background tasks
+    /// - Perform scheduling decisions
+    ///
+    /// The VCpu can typically be resumed immediately after these checks.
+    Nothing,
+
+    /// The guest is attempting to send an Inter-Processor Interrupt (IPI).
+    ///
+    /// IPIs are used for inter-CPU communication in multi-core systems.
+    /// This does **not** include Startup IPIs (SIPI), which are handled
+    /// by the [`AxVCpuExitReason::CpuUp`] variant.
+    SendIPI {
+        /// Target CPU identifier to receive the IPI
+        ///
+        /// This field is invalid if `send_to_all` or `send_to_self` is true.
+        target_cpu: u64,
+        /// Auxiliary field for complex target CPU specifications
+        ///
+        /// Currently used only on AArch64 where:
+        /// - `target_cpu` contains `Aff3.Aff2.Aff1.0`
+        /// - `target_cpu_aux` contains a bitmask for `Aff0` values
+        target_cpu_aux: u64,
+        /// Whether to broadcast the IPI to all CPUs except the sender
+        send_to_all: bool,
+        /// Whether to send the IPI to the current CPU (self-IPI)
+        send_to_self: bool,
+        /// IPI vector/interrupt number to deliver
+        vector: u64,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg(target_arch = "aarch64")]
 #![feature(doc_cfg)]
 #![doc = include_str!("../README.md")]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,7 @@ pub fn has_hardware_support() -> bool {
     // Current just return true by default.
     true
 }
+
+pub trait CpuHal {
+    fn inject_interrupt(irq: usize);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate alloc;
+
 mod context_frame;
 #[macro_use]
 mod exception_utils;
@@ -19,6 +22,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 pub use self::pcpu::Aarch64PerCpu;
 pub use self::vcpu::{Aarch64VCpu, Aarch64VCpuCreateConfig, Aarch64VCpuSetupConfig};
+use alloc::vec::Vec;
 pub use axvm_types::addr::*;
 pub use axvm_types::device::*;
 pub use exit::*;
@@ -40,6 +44,8 @@ pub fn has_hardware_support() -> bool {
 pub trait CpuHal {
     fn irq_hanlder(&self);
     fn inject_interrupt(&self, irq: usize);
+    /// Cpu hard id list
+    fn cpu_list(&self) -> Vec<usize>;
 }
 
 struct NopHal;
@@ -49,6 +55,10 @@ impl CpuHal for NopHal {
         unimplemented!()
     }
     fn inject_interrupt(&self, _irq: usize) {
+        unimplemented!()
+    }
+
+    fn cpu_list(&self) -> Vec<usize> {
         unimplemented!()
     }
 }
@@ -79,4 +89,6 @@ pub fn init_hal(hal: &'static dyn CpuHal) {
     } else {
         panic!("arm_vcpu hal has been initialized");
     }
+
+    unsafe { vcpu::init_host_sp_el0() };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 pub use self::pcpu::Aarch64PerCpu;
 pub use self::vcpu::{Aarch64VCpu, Aarch64VCpuCreateConfig, Aarch64VCpuSetupConfig};
+pub use axvm_types::addr::*;
+pub use axvm_types::device::*;
+pub use exit::*;
 
 /// context frame for aarch64
 pub type TrapFrame = context_frame::Aarch64ContextFrame;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 pub use self::pcpu::Aarch64PerCpu;
 pub use self::vcpu::{Aarch64VCpu, Aarch64VCpuCreateConfig, Aarch64VCpuSetupConfig};
 use alloc::vec::Vec;
-pub use axvm_types::addr::*;
-pub use axvm_types::device::*;
+pub use axvm_types::{addr::*, device::*};
 pub use exit::*;
 
 /// context frame for aarch64
@@ -91,4 +90,14 @@ pub fn init_hal(hal: &'static dyn CpuHal) {
     }
 
     unsafe { vcpu::init_host_sp_el0() };
+}
+
+#[derive(Debug, thiserror::Error, Clone)]
+pub enum VCpuError {
+    #[error("Bad state: {0}")]
+    BadState(&'static str),
+    #[error("Invalid argument: {0}")]
+    InvalidArg(&'static str),
+    #[error("Unsupported operation")]
+    Unsupported,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,3 @@ pub fn has_hardware_support() -> bool {
     // Current just return true by default.
     true
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,3 +29,4 @@ pub fn has_hardware_support() -> bool {
     // Current just return true by default.
     true
 }
+

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -60,6 +60,10 @@ impl Aarch64PerCpu {
         crate::vcpu::max_gpt_level(crate::vcpu::pa_bits())
     }
 
+    pub fn pa_bits(&self) -> usize {
+        crate::vcpu::pa_bits()
+    }
+
     pub fn pa_range(&self) -> core::ops::Range<usize> {
         let pa_bits = crate::vcpu::pa_bits();
         0..(1 << pa_bits)

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -59,4 +59,9 @@ impl Aarch64PerCpu {
     pub fn max_guest_page_table_levels(&self) -> usize {
         crate::vcpu::max_gpt_level(crate::vcpu::pa_bits())
     }
+
+    pub fn pa_range(&self) -> core::ops::Range<usize> {
+        let pa_bits = crate::vcpu::pa_bits();
+        0..(1 << pa_bits)
+    }
 }

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -23,7 +23,7 @@ static ORI_EXCEPTION_VECTOR_BASE: usize = 0;
 #[percpu::def_percpu]
 pub static IRQ_HANDLER: OnceCell<&(dyn Fn() + Send + Sync)> = OnceCell::new();
 
-unsafe extern "C" {
+unsafe extern {
     fn exception_vector_base_vcpu();
 }
 
@@ -82,5 +82,9 @@ impl<H: AxVCpuHal> AxArchPerCpu for Aarch64PerCpu<H> {
 
         HCR_EL2.set(HCR_EL2::VM::Disable.into());
         Ok(())
+    }
+
+    fn max_guest_page_table_levels(&self) -> usize {
+        crate::vcpu::max_gpt_level(crate::vcpu::pa_bits())
     }
 }

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -3,7 +3,6 @@ use core::{cell::OnceCell, marker::PhantomData};
 use aarch64_cpu::registers::*;
 use axerrno::AxResult;
 use axvcpu::{AxArchPerCpu, AxVCpuHal};
-use tock_registers::interfaces::ReadWriteable;
 
 /// Per-CPU data. A pointer to this struct is loaded into TP when a CPU starts. This structure
 #[repr(C)]
@@ -56,11 +55,7 @@ impl<H: AxVCpuHal> AxArchPerCpu for Aarch64PerCpu<H> {
         VBAR_EL2.set(exception_vector_base_vcpu as usize as _);
 
         HCR_EL2.modify(
-            HCR_EL2::VM::Enable
-                + HCR_EL2::RW::EL1IsAarch64
-                + HCR_EL2::IMO::EnableVirtualIRQ
-                + HCR_EL2::FMO::EnableVirtualFIQ
-                + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,
+            HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64 + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,
         );
 
         // Note that `ICH_HCR_EL2` is not the same as `HCR_EL2`.

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -9,8 +9,6 @@ use crate::CpuHal;
 #[repr(C)]
 #[repr(align(4096))]
 pub struct Aarch64PerCpu {
-    /// per cpu id
-    pub cpu_id: usize,
     ori_vbar: u64,
 }
 
@@ -19,18 +17,17 @@ unsafe extern "C" {
 }
 
 impl Aarch64PerCpu {
-    fn new(cpu_id: usize) -> AxResult<Self> {
-        Ok(Self {
-            cpu_id,
+    pub fn new() -> Self {
+        Self {
             ori_vbar: VBAR_EL2.get(),
-        })
+        }
     }
 
-    fn is_enabled(&self) -> bool {
+    pub fn is_enabled(&self) -> bool {
         HCR_EL2.is_set(HCR_EL2::VM)
     }
 
-    fn hardware_enable(&mut self) -> AxResult {
+    pub fn hardware_enable(&mut self) {
         // Set current `VBAR_EL2` to `exception_vector_base_vcpu`
         // defined in this crate.
         VBAR_EL2.set(exception_vector_base_vcpu as usize as _);
@@ -51,11 +48,9 @@ impl Aarch64PerCpu {
         //         value = in(reg) 0,
         //     }
         // }
-
-        Ok(())
     }
 
-    fn hardware_disable(&mut self) -> AxResult {
+    pub fn hardware_disable(&mut self) -> AxResult {
         // Reset `VBAR_EL2` into previous value.
         // Safety:
         // Todo: take care of `preemption`
@@ -65,7 +60,7 @@ impl Aarch64PerCpu {
         Ok(())
     }
 
-    fn max_guest_page_table_levels(&self) -> usize {
+    pub fn max_guest_page_table_levels(&self) -> usize {
         crate::vcpu::max_gpt_level(crate::vcpu::pa_bits())
     }
 }

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -1,5 +1,3 @@
-use core::cell::OnceCell;
-
 use aarch64_cpu::registers::*;
 use axerrno::AxResult;
 

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -23,7 +23,7 @@ static ORI_EXCEPTION_VECTOR_BASE: usize = 0;
 #[percpu::def_percpu]
 pub static IRQ_HANDLER: OnceCell<&(dyn Fn() + Send + Sync)> = OnceCell::new();
 
-unsafe extern {
+unsafe extern "C" {
     fn exception_vector_base_vcpu();
 }
 

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -23,7 +23,7 @@ static ORI_EXCEPTION_VECTOR_BASE: usize = 0;
 #[percpu::def_percpu]
 pub static IRQ_HANDLER: OnceCell<&(dyn Fn() + Send + Sync)> = OnceCell::new();
 
-unsafe extern "C" {
+unsafe extern {
     fn exception_vector_base_vcpu();
 }
 

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -26,7 +26,7 @@ impl Aarch64PerCpu {
     pub fn hardware_enable(&mut self) {
         // Set current `VBAR_EL2` to `exception_vector_base_vcpu`
         // defined in this crate.
-        VBAR_EL2.set(exception_vector_base_vcpu as usize as _);
+        VBAR_EL2.set(exception_vector_base_vcpu as *const () as usize as _);
 
         HCR_EL2.modify(
             HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64 + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -1,5 +1,6 @@
 use aarch64_cpu::registers::*;
-use axerrno::AxResult;
+
+use crate::VCpuError;
 
 /// Per-CPU data. A pointer to this struct is loaded into TP when a CPU starts. This structure
 #[repr(C)]
@@ -46,7 +47,7 @@ impl Aarch64PerCpu {
         // }
     }
 
-    pub fn hardware_disable(&mut self) -> AxResult {
+    pub fn hardware_disable(&mut self) -> Result<(), VCpuError> {
         // Reset `VBAR_EL2` into previous value.
         // Safety:
         // Todo: take care of `preemption`

--- a/src/pcpu.rs
+++ b/src/pcpu.rs
@@ -3,8 +3,6 @@ use core::cell::OnceCell;
 use aarch64_cpu::registers::*;
 use axerrno::AxResult;
 
-use crate::CpuHal;
-
 /// Per-CPU data. A pointer to this struct is loaded into TP when a CPU starts. This structure
 #[repr(C)]
 #[repr(align(4096))]

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -141,6 +141,14 @@ impl Aarch64VCpu {
         // Return value is stored in x0.
         self.ctx.set_argument(val);
     }
+
+    pub fn ctx(&self) -> &TrapFrame {
+        &self.ctx
+    }
+
+    pub fn ctx_mut(&mut self) -> &mut TrapFrame {
+        &mut self.ctx
+    }
 }
 
 // Private function

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -215,7 +215,7 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
     /// When a VM-Exit happens when guest's vCpu is running,
     /// the control flow will be redirected to this function through `return_run_guest`.
     #[unsafe(naked)]
-    unsafe extern fn run_guest(&mut self) -> usize {
+    unsafe extern "C" fn run_guest(&mut self) -> usize {
         // Fixes: https://github.com/arceos-hypervisor/arm_vcpu/issues/22
         //
         // The original issue seems to be caused by an unexpected compiler optimization that takes

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -72,7 +72,7 @@ pub struct Aarch64VCpuSetupConfig {
 }
 
 impl Aarch64VCpu {
-    fn new(_vm_id: usize, _vcpu_id: usize, config: Aarch64VCpuCreateConfig) -> AxResult<Self> {
+    pub fn new(config: Aarch64VCpuCreateConfig) -> AxResult<Self> {
         let mut ctx = TrapFrame::default();
         ctx.set_argument(config.dtb_addr);
 
@@ -84,24 +84,24 @@ impl Aarch64VCpu {
         })
     }
 
-    fn setup(&mut self, config: Aarch64VCpuSetupConfig) -> AxResult {
+    pub fn setup(&mut self, config: Aarch64VCpuSetupConfig) -> AxResult {
         self.init_hv(config);
         Ok(())
     }
 
-    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
+    pub fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
         debug!("set vcpu entry:{entry:?}");
         self.set_elr(entry.as_usize());
         Ok(())
     }
 
-    fn set_ept_root(&mut self, ept_root: HostPhysAddr) -> AxResult {
+    pub fn set_ept_root(&mut self, ept_root: HostPhysAddr) -> AxResult {
         debug!("set vcpu ept root:{ept_root:#x}");
         self.guest_system_regs.vttbr_el2 = ept_root.as_usize() as u64;
         Ok(())
     }
 
-    fn run(&mut self) -> AxResult<AxVCpuExitReason> {
+    pub fn run(&mut self) -> AxResult<AxVCpuExitReason> {
         // Run guest.
         let exit_reson = unsafe {
             // Save host SP_EL0 to the ctx becase it's used as current task ptr.
@@ -115,25 +115,25 @@ impl Aarch64VCpu {
         self.vmexit_handler(trap_kind)
     }
 
-    fn bind(&mut self) -> AxResult {
+    pub fn bind(&mut self) -> AxResult {
         Ok(())
     }
 
-    fn unbind(&mut self) -> AxResult {
+    pub fn unbind(&mut self) -> AxResult {
         Ok(())
     }
 
-    fn set_gpr(&mut self, idx: usize, val: usize) {
+    pub fn set_gpr(&mut self, idx: usize, val: usize) {
         self.ctx.set_gpr(idx, val);
     }
 
-    fn inject_interrupt(&mut self, vector: usize) -> AxResult {
+    pub fn inject_interrupt(&mut self, vector: usize) -> AxResult {
         inject_interrupt(vector);
         // axvisor_api::arch::hardware_inject_virtual_interrupt(vector as u8);
         Ok(())
     }
 
-    fn set_return_value(&mut self, val: usize) {
+    pub fn set_return_value(&mut self, val: usize) {
         // Return value is stored in x0.
         self.ctx.set_argument(val);
     }

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -119,35 +119,18 @@ impl Aarch64VCpu {
         self.vmexit_handler(trap_kind)
     }
 
-    pub fn bind(&mut self) -> AxResult {
-        Ok(())
-    }
-
-    pub fn unbind(&mut self) -> AxResult {
-        Ok(())
-    }
-
     pub fn set_gpr(&mut self, idx: usize, val: usize) {
         self.ctx.set_gpr(idx, val);
     }
 
     pub fn inject_interrupt(&mut self, vector: usize) -> AxResult {
         inject_interrupt(vector);
-        // axvisor_api::arch::hardware_inject_virtual_interrupt(vector as u8);
         Ok(())
     }
 
     pub fn set_return_value(&mut self, val: usize) {
         // Return value is stored in x0.
         self.ctx.set_argument(val);
-    }
-
-    pub fn ctx(&self) -> &TrapFrame {
-        &self.ctx
-    }
-
-    pub fn ctx_mut(&mut self) -> &mut TrapFrame {
-        &mut self.ctx
     }
 }
 

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 use aarch64_cpu::registers::*;
 use axerrno::AxResult;
 use axvm_types::{

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -215,7 +215,7 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
     /// When a VM-Exit happens when guest's vCpu is running,
     /// the control flow will be redirected to this function through `return_run_guest`.
     #[unsafe(naked)]
-    unsafe extern "C" fn run_guest(&mut self) -> usize {
+    unsafe extern fn run_guest(&mut self) -> usize {
         // Fixes: https://github.com/arceos-hypervisor/arm_vcpu/issues/22
         //
         // The original issue seems to be caused by an unexpected compiler optimization that takes

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -119,8 +119,7 @@ impl Aarch64VCpu {
         } + (VTCR_EL2::TG0::Granule4KB
             + VTCR_EL2::SH0::Inner
             + VTCR_EL2::ORGN0::NormalWBRAWA
-            + VTCR_EL2::IRGN0::NormalWBRAWA)
-            .value;
+            + VTCR_EL2::IRGN0::NormalWBRAWA);
         self.guest_system_regs.vtcr_el2 = val.value;
         VTCR_EL2.set(self.guest_system_regs.vtcr_el2);
 

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -167,60 +167,15 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
         self.guest_system_regs.sctlr_el1 = 0x30C50830;
         self.guest_system_regs.pmcr_el0 = 0;
 
-        // use 3 level ept paging
-        // - 4KiB granule (TG0)
-        // - 39-bit address space (T0_SZ)
-        // - start at level 1 (SL0)
-        #[cfg(not(feature = "4-level-ept"))]
-        {
-            self.guest_system_regs.vtcr_el2 = (VTCR_EL2::PS::PA_40B_1TB
-                + VTCR_EL2::TG0::Granule4KB
+        self.guest_system_regs.vtcr_el2 = probe_vtcr_support()
+            + (VTCR_EL2::TG0::Granule4KB
                 + VTCR_EL2::SH0::Inner
                 + VTCR_EL2::ORGN0::NormalWBRAWA
-                + VTCR_EL2::IRGN0::NormalWBRAWA
-                + VTCR_EL2::SL0.val(0b01)
-                + VTCR_EL2::T0SZ.val(64 - 39))
-            .into();
-        }
+                + VTCR_EL2::IRGN0::NormalWBRAWA)
+                .value;
 
-        // use 4 level ept paging
-        // - 4KiB granule (TG0)
-        // - 48-bit address space (T0_SZ)
-        // - start at level 0 (SL0)
-        #[cfg(feature = "4-level-ept")]
-        {
-            // read PARange (bits 3:0)
-            let parange = (ID_AA64MMFR0_EL1.get() & 0xF) as u8;
-            // ARM Definition: 0x5 indicates 48 bits PA, 0x4 indicates 44 bits PA, and so on.
-            if parange <= 0x4 {
-                panic!(
-                    "CPU only supports {}-bit PA (< 44), \
-                 cannot enable 4-level EPT paging!",
-                    match parange {
-                        0x0 => 32,
-                        0x1 => 36,
-                        0x2 => 40,
-                        0x3 => 42,
-                        0x4 => 44,
-                        _ => 48,
-                    }
-                );
-            }
-            self.guest_system_regs.vtcr_el2 = (VTCR_EL2::PS::PA_48B_256TB
-                + VTCR_EL2::TG0::Granule4KB
-                + VTCR_EL2::SH0::Inner
-                + VTCR_EL2::ORGN0::NormalWBRAWA
-                + VTCR_EL2::IRGN0::NormalWBRAWA
-                + VTCR_EL2::SL0.val(0b10) // 0b10 means start at level 0
-                + VTCR_EL2::T0SZ.val(64 - 48))
-            .into();
-        }
-
-        let mut hcr_el2 = HCR_EL2::VM::Enable
-            + HCR_EL2::RW::EL1IsAarch64
-            + HCR_EL2::FMO::EnableVirtualFIQ
-            + HCR_EL2::TSC::EnableTrapEl1SmcToEl2
-            + HCR_EL2::RW::EL1IsAarch64;
+        let mut hcr_el2 =
+            HCR_EL2::VM::Enable + HCR_EL2::TSC::EnableTrapEl1SmcToEl2 + HCR_EL2::RW::EL1IsAarch64;
 
         if !config.passthrough_interrupt {
             // Set HCR_EL2.IMO will trap IRQs to EL2 while enabling virtual IRQs.
@@ -228,7 +183,7 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
             // We must choose one of the two:
             // - Enable virtual IRQs and trap physical IRQs to EL2.
             // - Disable virtual IRQs and pass through physical IRQs to EL1.
-            hcr_el2 += HCR_EL2::IMO::EnableVirtualIRQ;
+            hcr_el2 += HCR_EL2::IMO::EnableVirtualIRQ + HCR_EL2::FMO::EnableVirtualFIQ;
         }
 
         self.guest_system_regs.hcr_el2 = hcr_el2.into();
@@ -440,4 +395,34 @@ impl<H: AxVCpuHal> Aarch64VCpu<H> {
             }
         }
     }
+}
+
+fn probe_vtcr_support() -> u64 {
+    let pa_bits = match ID_AA64MMFR0_EL1.read_as_enum(ID_AA64MMFR0_EL1::PARange) {
+        Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_32) => 32,
+        Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_36) => 36,
+        Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_40) => 40,
+        Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_42) => 42,
+        Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_44) => 44,
+        Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_48) => 48,
+        Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_52) => 52,
+        _ => 32,
+    };
+
+    let mut val = match pa_bits {
+        44.. => VTCR_EL2::SL0::Granule4KBLevel0 + VTCR_EL2::T0SZ.val(64 - 48),
+        _ => VTCR_EL2::SL0::Granule4KBLevel1 + VTCR_EL2::T0SZ.val(64 - 39),
+    };
+
+    match pa_bits {
+        52..=64 => val += VTCR_EL2::PS::PA_52B_4PB,
+        48..=51 => val += VTCR_EL2::PS::PA_48B_256TB,
+        44..=47 => val += VTCR_EL2::PS::PA_44B_16TB,
+        42..=43 => val += VTCR_EL2::PS::PA_42B_4TB,
+        40..=41 => val += VTCR_EL2::PS::PA_40B_1TB,
+        36..=39 => val += VTCR_EL2::PS::PA_36B_64GB,
+        _ => val += VTCR_EL2::PS::PA_32B_4GB,
+    }
+
+    val.value
 }

--- a/src/vcpu.rs
+++ b/src/vcpu.rs
@@ -89,6 +89,12 @@ impl Aarch64VCpu {
         Ok(())
     }
 
+    pub fn set_dtb_addr(&mut self, dtb_addr: GuestPhysAddr) -> AxResult {
+        debug!("set vcpu dtb addr:{dtb_addr:?}");
+        self.ctx.set_argument(dtb_addr.as_usize());
+        Ok(())
+    }
+
     pub fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
         debug!("set vcpu entry:{entry:?}");
         self.set_elr(entry.as_usize());


### PR DESCRIPTION
This pull request introduces significant refactoring and modernization to the `arm_vcpu` crate, focusing on improved modularity, architectural clarity, and compatibility with the `axvm_types` workspace. The most important changes include a redesign of per-CPU and vCPU abstractions to remove generic parameters, the addition of a new `AxVCpuExitReason` enum for VM exit handling, a new HAL (Hardware Abstraction Layer) interface for CPU operations, updates to dependencies and metadata, and adjustments to build and CI configurations for the `aarch64-unknown-none-softfloat` target.

### Architectural Refactoring and HAL Abstraction
- Removed generic parameters (`AxVCpuHal`) from `Aarch64PerCpu` and `Aarch64VCpu`, simplifying their usage and initialization. Introduced a new trait `CpuHal` and related initialization logic in `lib.rs` for hardware abstraction, along with default NOP implementations and safe singleton initialization. (`[[1]](diffhunk://#diff-cfbd13fb57529c6ffb629101fb244d55a2746c59484e7a9978342c34995c3b8eL1-R32)`, `[[2]](diffhunk://#diff-cfbd13fb57529c6ffb629101fb244d55a2746c59484e7a9978342c34995c3b8eL78-R70)`, `[[3]](diffhunk://#diff-c81313374d24e5697ee5c347b11fc7b156830230764577b85c5180a3ef7f1ecdL1-R14)`, `[[4]](diffhunk://#diff-c81313374d24e5697ee5c347b11fc7b156830230764577b85c5180a3ef7f1ecdL40-R52)`, `[[5]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R13-R24)`, `[[6]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R39-R82)`)
- Refactored IRQ handling to use the new HAL (`handle_irq`), eliminating the need for per-CPU function pointers or `OnceCell`. (`[[1]](diffhunk://#diff-1b3d9f91d532261d2032e8f484185b3c4bc5377fb42b19e780b751e936dd33e1L284-R285)`, `[[2]](diffhunk://#diff-1b3d9f91d532261d2032e8f484185b3c4bc5377fb42b19e780b751e936dd33e1R9-R19)`)

### VM Exit Reason Standardization
- Added a comprehensive and well-documented `AxVCpuExitReason` enum to `src/exit.rs`, capturing all major categories of VM exits (I/O, system events, power management, multiprocessing, errors, etc.) in a forward-compatible, extensible manner. (`[src/exit.rsR1-R191](diffhunk://#diff-df574c6f1903e886ddf07734496e1891b71f4507e4988e334d907b74dcb2b006R1-R191)`)
- Updated exception and vCPU modules to use the new `AxVCpuExitReason` and types from `axvm_types`. (`[[1]](diffhunk://#diff-1b3d9f91d532261d2032e8f484185b3c4bc5377fb42b19e780b751e936dd33e1R9-R19)`, `[[2]](diffhunk://#diff-c81313374d24e5697ee5c347b11fc7b156830230764577b85c5180a3ef7f1ecdL1-R14)`)

### Dependency and Metadata Updates
- Migrated from `axaddrspace` and related crates to `axvm_types` for address and device types, updating all usages accordingly. (`[[1]](diffhunk://#diff-1b3d9f91d532261d2032e8f484185b3c4bc5377fb42b19e780b751e936dd33e1R9-R19)`, `[[2]](diffhunk://#diff-799cbab61f90a6e923db567539632f95c9b72c073f817328c18a6b196220e929L1-R3)`, `[[3]](diffhunk://#diff-c81313374d24e5697ee5c347b11fc7b156830230764577b85c5180a3ef7f1ecdL1-R14)`)
- Updated `Cargo.toml` to add categories and keywords, adjust dependencies (e.g., update `aarch64-cpu` to 11.0), and reorganize metadata for clarity and workspace compatibility. (`[Cargo.tomlL2-L35](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L2-L35)`)

### Build and CI Improvements
- Added `.cargo/config.toml` to set the default build target to `aarch64-unknown-none-softfloat`. (`[.cargo/config.tomlR1-R2](diffhunk://#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268R1-R2)`)
- Updated GitHub Actions workflow to use a newer nightly toolchain and to build and deploy documentation for the correct target directory. (`[.github/workflows/ci.ymlL47-R59](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL47-R59)`)

### Exception and Debug Logging Enhancements
- Improved synchronous exception logging to include additional register values (`FAR_EL2`, `HPFAR_EL2`, `SPSR_EL2`) for better debugging. (`[src/exception.rsR294-R303](diffhunk://#diff-1b3d9f91d532261d2032e8f484185b3c4bc5377fb42b19e780b751e936dd33e1R294-R303)`)

These changes collectively modernize the codebase, improve maintainability, and prepare the crate for further development and integration in the `arceos-hypervisor` ecosystem.